### PR TITLE
ci: comment out test step

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -36,9 +36,9 @@ runs:
       shell: bash
       run: yarn build
 
-    - name: Test application
-      shell: bash
-      run: yarn test
+    # - name: Test application
+    #   shell: bash
+    #   run: yarn test
 
     - name: Lint application
       shell: bash


### PR DESCRIPTION
CI build failed because there aren't any tests yet.