### PR TITLE
fix: replace newlines

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,7 @@
       "type": "node",
       "request": "launch",
       "name": "Launch Program",
-      "skipFiles": [
-        "<node_internals>/**"
-      ],
+      "skipFiles": ["<node_internals>/**"],
       "program": "${workspaceFolder}/scratch.js"
     },
     {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,13 +36,7 @@
   "typescript.autoClosingTags": false,
   "typescript.suggest.completeJSDocs": false,
   "typescript.disableAutomaticTypeAcquisition": true,
-  "cSpell.words": [
-    "dev",
-    "hastscript",
-    "mdsvex",
-    "rehype",
-    "shiki"
-  ],
+  "cSpell.words": ["dev", "hastscript", "mdsvex", "rehype", "shiki"],
   "cSpell.ignorePaths": [
     "**/package-lock.json",
     "**/.svelte-kit/**",

--- a/etc/highlighter.api.md
+++ b/etc/highlighter.api.md
@@ -24,6 +24,14 @@ export type TMetadata = {
     lang?: string | undefined;
 };
 
+// @public (undocumented)
+export type TMetaToken = {
+    value: string;
+    start: number;
+    end: number;
+    type: "identifier" | "literal" | "symbol";
+};
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/scripts/build-pkg.js
+++ b/scripts/build-pkg.js
@@ -1,0 +1,15 @@
+import { exec } from "./utils/exec.js";
+
+if (!process.env.CI) {
+  await exec("yarn", ["clean:all"]);
+}
+
+try {
+  await exec("yarn", ["build:tsc"]);
+  await exec("yarn", ["build:esm"]);
+  await exec("yarn", ["build:types"]);
+} catch (code) {
+  process.exit(code);
+}
+
+process.exit(0);

--- a/scripts/build-types.js
+++ b/scripts/build-types.js
@@ -1,0 +1,29 @@
+import path from "path";
+import * as url from "url";
+
+import { exec } from "./utils/exec.js";
+
+const apiExtractorPath = path.resolve(
+  url.fileURLToPath(new URL(".", import.meta.url)),
+  "../node_modules/.bin/api-extractor"
+);
+
+// Strip `--local` out. It will be configured only by this script.
+const args = process.argv.slice(2).filter((arg) => arg !== "--local");
+
+// When in CI, `api-extractor` shouldn't apply the local flag. This script will
+// error if an API change occurs without being committed in an `api.md` file.
+const localFlag = process.env.CI ? [] : ["--local"];
+
+/**
+ * ApiExtractor CLI arguments.
+ */
+const apiExtractorArgs = ["run", ...args, ...localFlag];
+
+console.log(`api-extractor ${apiExtractorArgs.join(" ")}`);
+
+exec(apiExtractorPath, apiExtractorArgs)
+  .then(() => process.exit(0))
+  .catch((code) => {
+    process.exit(code);
+  });

--- a/scripts/utils/exec.js
+++ b/scripts/utils/exec.js
@@ -1,0 +1,38 @@
+import { spawn } from "node:child_process";
+
+/**
+ * Async `exec`.
+ *
+ * Inspired by `remix-run` build [scripts](https://github.com/remix-run/remix/blob/534e1ec071f17654a4db8622e30d6ff70548ce26/scripts/build.mjs).
+ *
+ * @param {string} command - Shell command to execute.
+ * @param {string[]} [args] - Command arguments.
+ * @param {import('node:child_process').SpawnOptions} options - Options to pass to `cross-spawn`.
+ * @returns {Promise<void>} Returns a Promise which resolves when `command` exits. If the exit code is non-zero, it rejects with the exit code.
+ */
+export function exec(command, args = [], options = {}) {
+  /** @type {(data: Error) => any} */
+  const handleError = (data) => console.error(data.toString().trim());
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: process.cwd(),
+      stdio: "inherit",
+      ...options,
+    });
+
+    const onExit = () => child.kill("SIGINT");
+
+    process.on("SIGINT", onExit);
+    process.on("SIGTERM", onExit);
+
+    child.on("error", handleError);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve(void 0);
+      } else {
+        reject(code);
+      }
+    });
+  });
+}

--- a/src/highlighter/hast-utils.ts
+++ b/src/highlighter/hast-utils.ts
@@ -62,10 +62,11 @@ function renderNode(node: TNode) {
   if (node.type === "text") {
     return renderText(node);
   } else {
+    const line = "dataLineNumber" in node.properties;
     const attributes = renderAttributes(node.properties);
     const children = node.children.map(renderNode).join("");
     const opening = node.tagName + (attributes.length > 1 ? " " + attributes : "");
-    return `<${opening}>${children}</${node.tagName}>`;
+    return `<${opening}>${children}</${node.tagName}>${line ? "\n" : ""}`;
   }
 }
 

--- a/src/highlighter/hast-utils.ts
+++ b/src/highlighter/hast-utils.ts
@@ -62,11 +62,12 @@ function renderNode(node: TNode) {
   if (node.type === "text") {
     return renderText(node);
   } else {
-    const line = "dataLineNumber" in node.properties;
+    // This is pretty hacky, but it works for now.
+    const newline = "dataLineNumber" in node.properties ? "\n" : "";
     const attributes = renderAttributes(node.properties);
     const children = node.children.map(renderNode).join("");
     const opening = node.tagName + (attributes.length > 1 ? " " + attributes : "");
-    return `<${opening}>${children}</${node.tagName}>${line ? "\n" : ""}`;
+    return `<${opening}>${children}</${node.tagName}>${newline}`;
   }
 }
 

--- a/src/highlighter/tsconfig.json
+++ b/src/highlighter/tsconfig.json
@@ -7,9 +7,7 @@
     "emitDeclarationOnly": false
   },
 
-  "references": [
-    { "path": "../parse-metadata" }
-  ],
+  "references": [{ "path": "../parse-metadata" }],
 
   "include": ["**/*"]
 }

--- a/src/parse-metadata/tsconfig.json
+++ b/src/parse-metadata/tsconfig.json
@@ -6,8 +6,7 @@
     "emitDeclarationOnly": false
   },
 
-  "references": [
-  ],
+  "references": [],
 
   "include": ["**/*"]
 }

--- a/src/parse-metadata/types.ts
+++ b/src/parse-metadata/types.ts
@@ -30,6 +30,9 @@ export type TMetadata = {
   lang?: string | undefined;
 };
 
+/**
+ * @public
+ */
 export type TMetaToken = {
   value: string;
   start: number;

--- a/src/tsconfig.base.json
+++ b/src/tsconfig.base.json
@@ -27,5 +27,5 @@
 
     "alwaysStrict": true,
     "newLine": "lf"
-  },
+  }
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.base",
   "files": ["./index.ts"],
   "compilerOptions": {
-    "emitDeclarationOnly": false,
+    "emitDeclarationOnly": false
   },
   "references": [{ "path": "./highlighter" }, { "path": "./parse-metadata" }]
 }


### PR DESCRIPTION
Shiki strips `\n` characters during tokenization. They should be replaced for pre-formatted code blocks to be displayed correctly.

fixes #8 

There are other fixes included in this PR.